### PR TITLE
Update E2 library

### DIFF
--- a/lua/cfw/extensions/mass_sv.lua
+++ b/lua/cfw/extensions/mass_sv.lua
@@ -23,6 +23,8 @@ hook.Add("cfw.contraption.created", "CFW_Mass", function(con)
 end)
 
 hook.Add("cfw.contraption.entityAdded", "CFW_Mass", function(con, ent)
+    if not IsValid(ent) then return end
+
     local obj = ent:GetPhysicsObject()
 
     if IsValid(obj) then
@@ -34,6 +36,8 @@ hook.Add("cfw.contraption.entityAdded", "CFW_Mass", function(con, ent)
 end)
 
 hook.Add("cfw.contraption.entityRemoved", "CFW_Mass", function(con, ent)
+    if not IsValid(ent) then return end
+
     local obj = ent:GetPhysicsObject()
 
     if IsValid(obj) then

--- a/lua/entities/gmod_wire_expression2/core/custom/cfw.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/cfw.lua
@@ -15,26 +15,12 @@ do -- Datatype and operator
         end
     )
 
-    registerOperator("ass", "xcr", "xcr", function(self, args)
-        local lhs, op2, scope = args[2], args[3], args[4]
-        local      rhs        = op2[1](self, op2)
-
-        self.Scopes[scope][lhs]      = rhs
-        self.Scopes[scope].vclk[lhs] = true
-
-        return rhs
-    end)
-
     e2function number operator_is(contraption cont)
 	    return isValidContraption(cont) and 1 or 0
     end
 
     e2function number operator==(contraption c1, contraption c2)
         return c1 == c2 and 1 or 0
-    end
-
-    e2function number operator!=(contraption c1, contraption c2)
-        return c1 ~= c2 and 1 or 0
     end
 end
 

--- a/lua/entities/gmod_wire_expression2/core/custom/cl_cfw.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/cl_cfw.lua
@@ -1,0 +1,6 @@
+E2Helper.Descriptions["isValid(xcr:)"] = "Returns 1 if the contraption is valid and 0 otherwise."
+E2Helper.Descriptions["getContraption(e:)"] = "Returns the contraption constrained to this entity."
+E2Helper.Descriptions["count(xcr:)"] = "Returns the number of entities in the contraption."
+E2Helper.Descriptions["getMass(xcr:)"] = "Returns the total mass of the contraption in kg."
+E2Helper.Descriptions["getTable(xcr:)"] = "Returns the E2 table of the contraption."
+E2Helper.Descriptions["getEntities(xcr:)"] = "Returns the entities contained in the contraption."


### PR DESCRIPTION
The E2 compiler rewrite that recently got merged (wiremod/wire#2555) removed the ass and != operators and now throws a serverside error on startup that complains about the registration of !=; this PR just removes those and adds some descriptions for all the E2 functions.