### PR TITLE
Fixed missing ENT._links error

### DIFF
--- a/lua/cfw/classes/link_sv.lua
+++ b/lua/cfw/classes/link_sv.lua
@@ -89,10 +89,13 @@ do
     end
 
     function ENT:GetLinks() -- Creates a shallow copy of the links table
-        local out = {}
+        local links = self._links
+        local out   = {}
 
-        for k, v in pairs(self._links) do
-            out[k] = v
+        if links then
+            for k, v in pairs(links) do
+                out[k] = v
+            end
         end
 
         return out

--- a/lua/cfw/core/connectivity_sv.lua
+++ b/lua/cfw/core/connectivity_sv.lua
@@ -65,7 +65,10 @@ end
 function CFW.disconnect(entA, indexB)
     if entA:EntIndex() == indexB then return end -- Should not happen normally, but ragdolls allow you to constrain to other bones on the same ragdoll, and it is the same entity
 
-    local link              = entA._links[indexB]
+    local link = entA._links[indexB]
+
+    if not link then return end -- There's nothing to disconnect here
+
     local contraptionPopped = link:Sub()
 
     if contraptionPopped then return end

--- a/lua/cfw/core/connectivity_sv.lua
+++ b/lua/cfw/core/connectivity_sv.lua
@@ -13,7 +13,7 @@ local function floodFill(source, sinkIndex)
 
         if entIndex == sinkIndex then return true, closed end
 
-        for neighborIndex, _ in pairs(Entity(entIndex)._links) do -- neighborIndex, neighborLink
+        for neighborIndex in pairs(Entity(entIndex)._links) do -- neighborIndex, neighborLink
             if not closed[neighborIndex] then
                 open[neighborIndex] = true
             end

--- a/lua/cfw/core/parenting_sv.lua
+++ b/lua/cfw/core/parenting_sv.lua
@@ -93,3 +93,17 @@ hook.Add("Initialize", "CFW", function()
 
     hook.Remove("Initialize", "CFW")
 end)
+
+-- In order to prevent NULL entities flooding the ENT._links table, we'll just get rid of them before they get removed
+-- This is a fix for a really annoying issue that was showing up in multiple different ways
+hook.Add("EntityRemoved", "cfw.entityRemoved", function(ent)
+    if not IsValid(ent) then return end
+
+    local links = ent:GetLinks()
+
+    if not links then return end
+
+    for index in pairs(links) do
+        disconnect(ent, index)
+    end
+end)


### PR DESCRIPTION
This was actually a really annoying issue to deal with, I'll explain everything I found out about it and the way I dealt with it. For starters, this error was showing up in multiple different ways, may it be because of a NULL entity or a point entity, but ultimately it was related to an entity missing a table:

```
[NULL Entity]
Entity [124][acf_debris]
Entity [196][entityflame]
Weapon [154][acf_torch] -- Genuinely concerned how this one happened
```

So I went onto checking at what point these entities were getting connected to the contraption, after all we're dealing with constraints here and you never know what Gmod could give you, with no avail. This led me to check the links of the source entity that was being disconnected and then floodfilled.

Just then, I noticed the source entity's links were **flooded** with NULL entities, hundreds of them in one of the many debug prints I got, that were inferfering, so now a race condition was on the table. It still didn't explain stuff like the debris and flames being attached to the contraption, after all they're just stuff that gets thrown around when something explodes.

After adding more and more information to the link table debug, I finally noticed what was happening.

`Entity [125][entityflame] prop_physics[125] gmod_wire_gate[117]`

So here's the trouble with this snippet: Our first entity, the flame, is called using the ID stored by the link, and the next two are the classes and ID of the entities that were originally stored on that specific link. What was originally the ID of a prop is now the ID of the flame entity.

This means we were not only dealing with one race condition but **TWO** race conditions, one for the many entities being removed too quickly and another for entities being spawned and using the IDs of these entities as soon as they're removed.

My solution was to simply hook onto `EntityRemoved` and disconnect all the entities linked to the one being deleted, after 30 solid minutes of blowing up my test vehicle I wasn't able to replicate the issue again. Even though a whole 100 dupes didn't create a single error, I highly recommend more people to test this fix.